### PR TITLE
Fix strange number bug

### DIFF
--- a/src/Firrtl/Lo/TypeCheck/Expr.hs
+++ b/src/Firrtl/Lo/TypeCheck/Expr.hs
@@ -39,7 +39,7 @@ alg ctx (RefF ident) =
 alg _ (LitF l) = case l of
   UInt mwidth value ->
     let minWidth = minUIntBitWidth value
-        width = traceShow (minUIntBitWidth 0) $ traceShow minWidth $ fromMaybe minWidth mwidth
+        width = fromMaybe minWidth mwidth
      in if minWidth > width
            then Left $ NotEnoughWidth l minWidth
            else Right $ case toSing width of
@@ -72,12 +72,11 @@ alg _ (MuxF (Safe.MkSomeExpr sc ec) (Safe.MkSomeExpr sl el) (Safe.MkSomeExpr sr 
     _ -> Left $ NoTopModule "conditional signal"
 
 minUIntBitWidth :: Natural -> Width
-minUIntBitWidth x = traceShowId . (+) 1
-            . traceShowId . fromIntegral
-            . traceShowId . (floor :: Double -> Int)
-            . traceShowId . logBase 2
-            . traceShowId . fromIntegral
-            $ trace ("Starting with " <> show x) x
+minUIntBitWidth = (+) 1
+            . fromIntegral
+            . (floor :: Double -> Int)
+            . max 0 . logBase 2
+            . fromIntegral
 
 minSIntBitWidth :: Int -> Width
 minSIntBitWidth x | x > 0 = 1 + minUIntBitWidth (fromIntegral x)

--- a/src/Firrtl/Lo/TypeCheck/Expr.hs
+++ b/src/Firrtl/Lo/TypeCheck/Expr.hs
@@ -38,10 +38,10 @@ alg ctx (RefF ident) =
 
 alg _ (LitF l) = case l of
   UInt mwidth value ->
-    let minWidth = traceShow value $ minUIntBitWidth value
+    let minWidth = minUIntBitWidth value
         width = traceShow (minUIntBitWidth 0) $ traceShow minWidth $ fromMaybe minWidth mwidth
      in if minWidth > width
-           then Left $ NotEnoughWidth l minWidth 
+           then Left $ NotEnoughWidth l minWidth
            else Right $ case toSing width of
                         SomeSing sn ->
                           let s = STuple3 SUnsigned sn SMale
@@ -51,7 +51,7 @@ alg _ (LitF l) = case l of
     let minWidth = minSIntBitWidth value
         width = fromMaybe minWidth mwidth
      in if minWidth > width
-           then Left $ NotEnoughWidth l minWidth 
+           then Left $ NotEnoughWidth l minWidth
            else Right $ case toSing width of
                         SomeSing sn ->
                           let s = STuple3 SSigned sn SMale
@@ -72,11 +72,12 @@ alg _ (MuxF (Safe.MkSomeExpr sc ec) (Safe.MkSomeExpr sl el) (Safe.MkSomeExpr sr 
     _ -> Left $ NoTopModule "conditional signal"
 
 minUIntBitWidth :: Natural -> Width
-minUIntBitWidth = (+) 1
-            . fromIntegral
-            . (floor :: Double -> Int)
-            . logBase 2
-            . fromIntegral
+minUIntBitWidth x = traceShowId . (+) 1
+            . traceShowId . fromIntegral
+            . traceShowId . (floor :: Double -> Int)
+            . traceShowId . logBase 2
+            . traceShowId . fromIntegral
+            $ trace ("Starting with " <> show x) x
 
 minSIntBitWidth :: Int -> Width
 minSIntBitWidth x | x > 0 = 1 + minUIntBitWidth (fromIntegral x)


### PR DESCRIPTION
(See first commit for debugging utilities)

There was issue with `minUIntBitWidth` number calculation, so i debugged each operation made by it:
```
λ: :main tests/circuits/trivial_sim.fir 
Starting with 3
3.0
1.5849625007211563
1
Width {unWidth = 1}
Width {unWidth = 2}
Starting with 0
0.0
-Infinity
0
Width {unWidth = 0}
Width {unWidth = 1}
Width {unWidth = 1}
Starting with 0
0.0
-Infinity
0
Width {unWidth = 0}
Width {unWidth = 1}
Width {unWidth = 1}
circuit Trivial :
  module Trivial : 
    input   clock : Clock
    input   reset : UInt<1>
    output  b     : SInt<4>
    ( node n1 = SInt<4>(-4), node n2 = SInt<4>(3), b <= mux(UInt<1>(0), n1, n2)
fromList [("n2",3),("n1",-4),("b",3)]
```

``` stack exec rtl -- tests/circuits/trivial_sim.fir
Starting with 3
3.0
1.5849625007211563
1
Width {unWidth = 1}
Width {unWidth = 2}
Starting with 0
0.0
-Infinity
9223372036854775807
Width {unWidth = 9223372036854775807}
Width {unWidth = 9223372036854775808}
Starting with 0
0.0
-Infinity
9223372036854775807
Width {unWidth = 9223372036854775807}
Width {unWidth = 9223372036854775808}
Width {unWidth = 9223372036854775808}
Width {unWidth = 9223372036854775808}
rtl: user error (NotEnoughWidth (UInt (Just (Width {unWidth = 1})) 0) (Width {unWidth = 9223372036854775808}))
```

In GHCi, `floor (-inf :: Double)` evaluates to 0, whereas on executable to 9223372036854775807.
So to keep desired behavior from GHCi, check is needed before calling `floor`.